### PR TITLE
Updated rioxxterms:type & ali_license_ref

### DIFF
--- a/webroot/content/profiles/v3-0-beta-1/ali_license_ref.md
+++ b/webroot/content/profiles/v3-0-beta-1/ali_license_ref.md
@@ -1,25 +1,24 @@
 ---
-date: '2016-03-21T10:00:43+00:00'
+date: '2020-10-09T10:00:43+00:00'
 draft: false
 type: metadata_profile_property
 title: ali:license_ref
 cardinality: One or more
 requirement: Mandatory
-metadata_profile: v2-0-final
+metadata_profile: v3-0-draft
 ---
-This is defined in the [NISO Open Access Metadata and Indicators](http://www.niso.org/workrooms/ali/). This element **MUST** take an HTTP URI for its value. This HTTP URI **MUST** point to a resource which expresses the license terms specifying how ***the resource*** may be used.
+This is defined in the [NISO Open Access Metadata and Indicators](http://www.niso.org/workrooms/ali/). This element **MUST** take an HTTP(S) URI for its value. This URI **MUST** point to a resource which expresses the license terms specifying how ***the resource*** may be used.
+
+Element content **MUST** be encoded according to the [W3CDTF](https://www.w3.org/TR/NOTE-datetime) (a profile of [ISO 8601](https://www.iso.org/standard/40874.html)) which typically follows the following format: YYYY-MM-DD.
 
 This element **MUST** include the attribute:
 
 * start_date
 
-This attribute takes a date value which **MUST** be encoded using ISO 8601 (post&#8211;2004 versions) which follows the following format: YYYY-MM-DD.
-
 This attribute is used to indicate the date upon which this license takes effect. Multiple *ali:license_ref* elements may be included. Where several such elements are included, the one with the *start_date* attribute indicating the most recent date takes precedence.
 
-Example:
-    
-    <ali:license_ref start_date="2015-02-17">http://creativecommons.org/licenses/by/4.0</ali:license_ref>
+Example:    
+    <ali:license_ref start_date="2019-11-17">http://creativecommons.org/licenses/by/4.0</ali:license_ref>
 
 This approach allows the expression of &#39;embargoes&#39;, where a particular license takes effect at a date in the subjective future.
 

--- a/webroot/content/profiles/v3-0-beta-1/rioxxterms_fulltext_deposit_date.md
+++ b/webroot/content/profiles/v3-0-beta-1/rioxxterms_fulltext_deposit_date.md
@@ -1,13 +1,13 @@
 ---
 date: '2020-10-08T10:00:43+00:00'
-draft: true
+draft: false
 type: metadata_profile_property
 title: rioxxterms:fulltext_deposit_date
 cardinality: Zero or one
 requirement: Optional
 metadata_profile: v3-0-draft
 ---
-This element takes the date on which ***the resource*** was first deposited, irrespective of any relevant embargoes or dark archiving, and irrespective of any subsequent file replacement(s). Element content should be encoded according to the [W3CDTF](https://www.w3.org/TR/NOTE-datetime) (a profile of [ISO 8601](https://www.iso.org/standard/40874.html)) which typically follows the following format: YYYY-MM-DD.
+This element takes the date on which ***the resource*** was first deposited, irrespective of any relevant embargoes or dark archiving, and irrespective of any subsequent file replacement(s). Element content **MUST** be encoded according to the [W3CDTF](https://www.w3.org/TR/NOTE-datetime) (a profile of [ISO 8601](https://www.iso.org/standard/40874.html)) which typically follows the following format: YYYY-MM-DD.
 
 Examples:
 

--- a/webroot/content/profiles/v3-0-beta-1/rioxxterms_record_public_release_date.md
+++ b/webroot/content/profiles/v3-0-beta-1/rioxxterms_record_public_release_date.md
@@ -1,13 +1,13 @@
 ---
 date: '2020-10-08T10:00:43+00:00'
-draft: true
+draft: false
 type: metadata_profile_property
 title: rioxxterms:record_public_release_date
 cardinality: Zero or one
 requirement: Optional
 metadata_profile: v3-0-draft
 ---
-This element takes the date upon which *metadata* about ***the resource*** being described was first made publicly visible. Element content should be encoded according to the [W3CDTF](https://www.w3.org/TR/NOTE-datetime) (a profile of [ISO 8601](https://www.iso.org/standard/40874.html)) which typically follows the following format: YYYY-MM-DD.
+This element takes the date upon which *metadata* about ***the resource*** being described was first made publicly visible. Element content **MUST** be encoded according to the [W3CDTF](https://www.w3.org/TR/NOTE-datetime) (a profile of [ISO 8601](https://www.iso.org/standard/40874.html)) which typically follows the following format: YYYY-MM-DD.
 
 Examples:
 

--- a/webroot/content/profiles/v3-0-beta-1/rioxxterms_resource_exposed_date.md
+++ b/webroot/content/profiles/v3-0-beta-1/rioxxterms_resource_exposed_date.md
@@ -7,7 +7,7 @@ cardinality: Zero or one
 requirement: Optional
 metadata_profile: v3-0-draft
 ---
-This element captures the date on which ***the resource*** is made publicly available. Element content should be encoded according to the [W3CDTF](https://www.w3.org/TR/NOTE-datetime) (a profile of [ISO 8601](https://www.iso.org/standard/40874.html)) which typically follows the following format: YYYY-MM-DD.
+This element captures the date on which ***the resource*** is made publicly available. Element content **MUST** be encoded according to the [W3CDTF](https://www.w3.org/TR/NOTE-datetime) (a profile of [ISO 8601](https://www.iso.org/standard/40874.html)) which typically follows the following format: YYYY-MM-DD.
 
 Examples:
 

--- a/webroot/content/profiles/v3-0-beta-1/rioxxterms_type.md
+++ b/webroot/content/profiles/v3-0-beta-1/rioxxterms_type.md
@@ -1,27 +1,20 @@
 ---
-date: '2016-03-21T10:00:43+00:00'
+date: '2020-10-09T14:00:43+00:00'
 draft: false
 type: metadata_profile_property
 title: rioxxterms:type
 cardinality: One or more
 requirement: Mandatory
-metadata_profile: v2-0-final
+metadata_profile: v3-0-draft
 ---
-Type refers to the 'type' - the nature or genre of the content of ***the resource***. Take care not to confuse this with *dc&#58;format*.
+Type refers to the 'type' - the nature or genre of the content of ***the resource***. This element should not be confused this with `dc:format`.
 
-Values recorded here **MUST** be from the following controlled list of types:
+Values recorded at `rioxxterms:type` **MUST** be taken from the [COAR Controlled Vocabulary for Resource Type Genres](http://vocabularies.coar-repositories.org/documentation/resource_types/) (Version 2.0), which provides a hierarchical model of resource type genres supported by language independent HTTP(S) URIs.
 
-* Book
-* Book chapter
-* Book edited
-* Conference Paper/Proceeding/Abstract
-* Journal Article/Review
-* Manual/Guide
-* Monograph
-* Policy briefing report
-* Technical Report
-* Technical Standard
-* Thesis
-* Other
-* Consultancy Report
-* Working paper
+Example:
+
+    <rioxxterms:type id="http://purl.org/coar/resource_type/c_5794">
+        conference paper
+    </rioxxterms:type>
+
+The COAR Controlled Vocabulary for Resource Type Genres is detailed in its treatment of type genres. It is anticipated that only the largest repositories would accommodate all vocabulary values, with most others implementing a subset in line with the resource types managed by the repository.


### PR DESCRIPTION
Updates to rioxxterms:type to accommodate COAR vocabulary for genre types, updates to license_ref and refinements to newly create elements.