### PR TITLE
Update to Rioxx name

### DIFF
--- a/webroot/content/profiles/v3-0-rc-1/index.md
+++ b/webroot/content/profiles/v3-0-rc-1/index.md
@@ -4,7 +4,7 @@ date: '2022-03-31T15:00:43+00:00'
 description: ''
 draft: false
 tags: []
-title: RIOXX Application Profile Version 3.0 Release Candidate 1
+title: Rioxx: The Research Outputs Metadata Schema Version 3.0 Release Candidate 1
 topics: []
 aliases:
 status: draft


### PR DESCRIPTION
Title change to reflect update from 'RIOXX Metadata Application Profile' to 'Rioxx: The Research Outputs Metadata Schema'.