### PR TITLE
Typo in the guidelines

### DIFF
--- a/webroot/content/profiles/v3-0-rc-1/dcterms_dateAccepted.md
+++ b/webroot/content/profiles/v3-0-rc-1/dcterms_dateAccepted.md
@@ -2,7 +2,7 @@
 date: '2020-10-28T15:10:43+00:00'
 draft: false
 type: metadata_profile_property
-title: dcterms:date_accepted
+title: dcterms:dateAccepted
 cardinality: Exactly one
 requirement: Mandatory
 metadata_profile: v3-0-rc-1


### PR DESCRIPTION
It is "dcterms:dateAccepted" in the dcterms schema (https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/dateAccepted), I think it is just a little typo as everywhere else in the docs is correct :)