### PR TITLE
Re-instate schema.org URI fix

### DIFF
--- a/webroot/content/profiles/v3-0-rc-1/dc_relation.md
+++ b/webroot/content/profiles/v3-0-rc-1/dc_relation.md
@@ -42,7 +42,7 @@ The [schema.org](https://schema.org/) vocabulary accommodates a diverse range of
 
 Examples:
 ```xml
-<dc:relation type="https://schema.org/DataSet" deposit_date="2022-01-13" resource_exposed_date="2022-01-20">
+<dc:relation type="https://schema.org/Dataset" deposit_date="2022-01-13" resource_exposed_date="2022-01-20">
     https://doi.org/10.5281/zenodo.3538919
 </dc:relation>
 ```


### PR DESCRIPTION
Unsure why -- probably a pull conflict -- but this fix was un-done recently. Re-implementing here.