### PR TITLE
RGG membership update

### DIFF
--- a/webroot/content/governance/_index.md
+++ b/webroot/content/governance/_index.md
@@ -9,11 +9,12 @@ topics: []
 ---
 
 ## Membership
-* George Macgregor, University of Strathclyde (Chair)
+* George Macgregor, University of Glasgow (Chair)
 * Nicola Dowson, The Open University
 * Michael Eadie, University of Glasgow
 * Beverley Jones, University of Sheffield
 * Petr Knoth, Knowledge Media institute, The Open University (representing CORE)
+* Agustina Martínez-García, University of Cambridge
 * Paul Walk, Antleaf Ltd.
 
 #### Previous Membership


### PR DESCRIPTION
RGG membership update to reflect changes in GM's institutional affiliation and the arrival of AGM to the membership.