### PR TITLE
Update to wording in dc:relation

### DIFF
--- a/webroot/content/profiles/v3-0-final/dc_relation.md
+++ b/webroot/content/profiles/v3-0-final/dc_relation.md
@@ -8,10 +8,10 @@ requirement: Should
 metadata_profile: v3-0-final
 ---
 
-Although this property is not strictly mandated in the Rioxx application profile, it **SHOULD** be included because this is the property which harvesting software will inspect to locate URLs for resource file content - for example to locate the "full text" associated with a repository record. It will also be the property to declare a persistent identifier (PID) that may be associated with such file content(s).  
+Although this property is not strictly mandated in the Rioxx application profile, it **SHOULD** be included because this is the property which harvesting software will inspect to locate URLs for resource file content - for example to locate the "full text" associated with a repository record. It will also be the property to declare a persistent identifier (PID) that may be associated with such file content(s). 
 
-When set to `rel="item"`, the `dc:relation` property identifies a downloadable resource. Each such `dc:relation` property **MUST** contain an HTTP(S) URI resolving to the downloadable resource. 
-
+When set to `rel="item"`, the `dc:relation` property identifies a downloadable resource. Each such `dc:relation` property **MUST** contain an HTTP(S) URI resolving to the downloadable resource. Note that only those resources under the direct custodianship of the repository should asserted within `dc:relation`. Entities outside the custodianship of the repository should be related using `rioxxterms:ext_relation`.  
+ 
 `dc:relation` is refined by a series of attributes, which **SHOULD** be included (where applicable): 
 
 * `rel`


### PR DESCRIPTION
Update to wording in dc:relation to highlight distinction between dc:relation and ext_relation.