### PR TITLE
Update order of elements in table

### DIFF
--- a/webroot/static/schema/v3.0/rioxx/rioxx.xsd
+++ b/webroot/static/schema/v3.0/rioxx/rioxx.xsd
@@ -155,7 +155,7 @@ When set to rel="cite-as", the dc:relation property specifies a cite-able identi
 
 dc:relation MUST only be used to identify resources under the direct custodianship of the repository, therefore all URIs
 specified under dc:relation MUST resolve to the repository. URIs identifying related resources that resolve to resources
-outside of the direct custodianship of the repository MUST be specified under rioxterms:ext_relation.
+outside of the direct custodianship of the repository MUST be specified under rioxxterms:ext_relation.
 
 The dc:relation property can be repeated to specify more than one associated resource. Possible values here may include
 a DOI, URN, CORE OAI ID; or an alternative repository HTTP(S) URI where there is no requirement for a PID.
@@ -337,7 +337,7 @@ Each external relation MUST appear as a separate instance of the rioxxterms:ext_
 
 rioxxterms:ext_relation MUST include the rel and coar_type attributes. The coar_version attribute MAY be included (where appropriate), if the related resource is a publication.
 
-rel: The rel attribute uses 'typed links' from the IANA Link Relation Registry. As Rioxx uses rioxxterms:ext_relation to communicate external associations, this attribute will normally be set to "cite-as", e.g. rel='cite-as' when the rioxterms:ext_relation conveys a related PID resolving to an external resource or rel='item' when rioxterms:ext_relation identifies a downloadable external resource.
+rel: The rel attribute uses 'typed links' from the IANA Link Relation Registry. As Rioxx uses rioxxterms:ext_relation to communicate external associations, this attribute will normally be set to "cite-as", e.g. rel='cite-as' when the rioxxterms:ext_relation conveys a related PID resolving to an external resource or rel='item' when rioxxterms:ext_relation identifies a downloadable external resource.
 
 coar_type: The coar_type attribute MUST contain an identifier from the COAR Resource Types Vocabulary. For example, for the common case of the related resource being a PDF of a journal article, the RECOMMENDED value would be http://purl.org/coar/resource_type/c_6501. The COAR Resource Types Vocabulary accommodates a diverse range of resource types.
 

--- a/webroot/static/schema/v3.0/rioxx/rioxx_.html
+++ b/webroot/static/schema/v3.0/rioxx/rioxx_.html
@@ -624,7 +624,7 @@ When set to rel="cite-as", the dc:relation property specifies a cite-able identi
 
 dc:relation MUST only be used to identify resources under the direct custodianship of the repository, therefore all URIs
 specified under dc:relation MUST resolve to the repository. URIs identifying related resources that resolve to resources
-outside of the direct custodianship of the repository MUST be specified under rioxterms:ext_relation.
+outside of the direct custodianship of the repository MUST be specified under rioxxterms:ext_relation.
 
 The dc:relation property can be repeated to specify more than one associated resource. Possible values here may include
 a DOI, URN, CORE OAI ID; or an alternative repository HTTP(S) URI where there is no requirement for a PID.
@@ -812,7 +812,7 @@ Each external relation MUST appear as a separate instance of the rioxxterms:ext_
 
 rioxxterms:ext_relation MUST include the rel and coar_type attributes. The coar_version attribute MAY be included (where appropriate), if the related resource is a publication.
 
-rel: The rel attribute uses 'typed links' from the IANA Link Relation Registry. As Rioxx uses rioxxterms:ext_relation to communicate external associations, this attribute will normally be set to "cite-as", e.g. rel='cite-as' when the rioxterms:ext_relation conveys a related PID resolving to an external resource or rel='item' when rioxterms:ext_relation identifies a downloadable external resource.
+rel: The rel attribute uses 'typed links' from the IANA Link Relation Registry. As Rioxx uses rioxxterms:ext_relation to communicate external associations, this attribute will normally be set to "cite-as", e.g. rel='cite-as' when the rioxxterms:ext_relation conveys a related PID resolving to an external resource or rel='item' when rioxxterms:ext_relation identifies a downloadable external resource.
 
 coar_type: The coar_type attribute MUST contain an identifier from the COAR Resource Types Vocabulary. For example, for the common case of the related resource being a PDF of a journal article, the RECOMMENDED value would be http://purl.org/coar/resource_type/c_6501. The COAR Resource Types Vocabulary accommodates a diverse range of resource types.
 

--- a/webroot/static/schema/v3.0/rioxx/rioxxterms.xsd
+++ b/webroot/static/schema/v3.0/rioxx/rioxxterms.xsd
@@ -144,7 +144,7 @@ rioxxterms:ext_relation MUST include the rel and coar_type attributes.
 The coar_version attribute MAY be included (where appropriate), if the related resource is a publication.
 
 1. rel: The rel attribute uses 'typed links' from the IANA Link Relation Registry.
-As Rioxx uses rioxxterms:ext_relation to communicate external associations, this attribute will normally be set to "cite-as", e.g. rel='cite-as' when the rioxterms:ext_relation conveys a related PID resolving to an external resource or rel='item' when rioxterms:ext_relation identifies a downloadable external resource.
+As Rioxx uses rioxxterms:ext_relation to communicate external associations, this attribute will normally be set to "cite-as", e.g. rel='cite-as' when the rioxxterms:ext_relation conveys a related PID resolving to an external resource or rel='item' when rioxxterms:ext_relation identifies a downloadable external resource.
 
 2. coar_type: The coar_type attribute MUST contain an identifier from the COAR Resource Types Vocabulary.
 For example, for the common case of the related resource being a PDF of a journal article, the RECOMMENDED value would be http://purl.org/coar/resource_type/c_6501. The COAR Resource Types Vocabulary accommodates a diverse range of resource types.

--- a/webroot/static/schema/v3.0/rioxx/rioxxterms_.html
+++ b/webroot/static/schema/v3.0/rioxx/rioxxterms_.html
@@ -1195,7 +1195,7 @@ SHOULD be used to indicate which of the rioxxterms:creator elements describes th
 </span><span class="tT">The coar_version attribute MAY be included (where appropriate), if the related resource is a publication.</span><span class="tI">
 </span><span class="tT"></span><span class="tI">
 </span><span class="tT">1. rel: The rel attribute uses 'typed links' from the IANA Link Relation Registry.</span><span class="tI">
-</span><span class="tT">As Rioxx uses rioxxterms:ext_relation to communicate external associations, this attribute will normally be set to "cite-as", e.g. rel='cite-as' when the rioxterms:ext_relation conveys a related PID resolving to an external resource or rel='item' when rioxterms:ext_relation identifies a downloadable external resource.</span><span class="tI">
+</span><span class="tT">As Rioxx uses rioxxterms:ext_relation to communicate external associations, this attribute will normally be set to "cite-as", e.g. rel='cite-as' when the rioxxterms:ext_relation conveys a related PID resolving to an external resource or rel='item' when rioxxterms:ext_relation identifies a downloadable external resource.</span><span class="tI">
 </span><span class="tT"></span><span class="tI">
 </span><span class="tT">2. coar_type: The coar_type attribute MUST contain an identifier from the COAR Resource Types Vocabulary.</span><span class="tI">
 </span><span class="tT">For example, for the common case of the related resource being a PDF of a journal article, the RECOMMENDED value would be http://purl.org/coar/resource_type/c_6501. The COAR Resource Types Vocabulary accommodates a diverse range of resource types.</span><span class="tI">
@@ -1339,7 +1339,7 @@ rioxxterms:ext_relation MUST include the rel and coar_type attributes.
 The coar_version attribute MAY be included (where appropriate), if the related resource is a publication.
 
 1. rel: The rel attribute uses 'typed links' from the IANA Link Relation Registry.
-As Rioxx uses rioxxterms:ext_relation to communicate external associations, this attribute will normally be set to "cite-as", e.g. rel='cite-as' when the rioxterms:ext_relation conveys a related PID resolving to an external resource or rel='item' when rioxterms:ext_relation identifies a downloadable external resource.
+As Rioxx uses rioxxterms:ext_relation to communicate external associations, this attribute will normally be set to "cite-as", e.g. rel='cite-as' when the rioxxterms:ext_relation conveys a related PID resolving to an external resource or rel='item' when rioxxterms:ext_relation identifies a downloadable external resource.
 
 2. coar_type: The coar_type attribute MUST contain an identifier from the COAR Resource Types Vocabulary.
 For example, for the common case of the related resource being a PDF of a journal article, the RECOMMENDED value would be http://purl.org/coar/resource_type/c_6501. The COAR Resource Types Vocabulary accommodates a diverse range of resource types.

--- a/webroot/themes/rioxx/layouts/profiles/single.html
+++ b/webroot/themes/rioxx/layouts/profiles/single.html
@@ -26,7 +26,7 @@
                 </tr>
                 </thead>
                 <tbody>
-                {{ range .Resources.Match "*.md" }}
+                {{ range sort (.Resources.Match "*.md") ".Title" }}
                     <tr>
                         <td><a id="{{.Title}}"></a>{{.Title}}</td>
                         <td>{{.Params.cardinality}}</td>


### PR DESCRIPTION
Fixes #69 

Also correct some spelling from `rioxterms` (`riox` with one 'x' was a v1 namespace, so probably worth correcting these instances).
Not sure if some of the .html/.md pages are generated from the XSDs - in which case manual edits to those may have been unnecessary.

NB some cases still remain in `webroot/content/profiles/v3-0-final/dc_relation.md` and  `webroot/content/profiles/v3-0-final/rioxxterms_ext_relation.md`, but these are in the pre-release documentation.